### PR TITLE
chore(seo): follow the repo rename and unify brand naming

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ version = "0.8.10"
 edition = "2021"
 rust-version = "1.93"
 license = "GPL-3.0-or-later"
-repository = "https://github.com/flowmux-ai/flowmux-terminal"
+repository = "https://github.com/flowmux-ai/flowmux"
 authors = ["The flowmux Authors"]
 
 [workspace.dependencies]

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 
 <div align="center">
   
-# Flowmux
+# flowmux
 ![icon](resources/icons/flowmux-180.png)
 
 **Agent Workflow Multiplexer Terminal** — *Go with the agents' flow.*
 
-[Website](https://flowmux-ai.github.io/) · [Latest release](https://github.com/flowmux-ai/flowmux-terminal/releases/latest)
+[Website](https://flowmux.org/) · [Latest release](https://github.com/flowmux-ai/flowmux/releases/latest)
 
 <img src=resources/screenshot/screenshot_1.gif  width="850"/>
 
@@ -172,7 +172,7 @@ The image viewer loads **ThorVG** at runtime (`dlopen`). It is **optional** —
 flowmux builds and runs without it; only the image viewer needs it, and shows a
 "ThorVG is not installed" message until it is present (no rebuild needed).
 
-On macOS, install the Homebrew package and restart FlowMux:
+On macOS, install the Homebrew package and restart flowmux:
 
 ```bash
 brew install thorvg
@@ -225,7 +225,7 @@ scripts/check-ubuntu-compat.sh # Docker smoke check for 24.04/26.04
 ```
 
 The Monaco editor bundle under `editor/flowmux-editor-web/dist` is committed,
-so regular Flowmux builds and installs do not require Node.js. Only developers
+so regular flowmux builds and installs do not require Node.js. Only developers
 who change the editor frontend need Node.js 20 or newer and npm. Rebuild and
 verify the locked assets with:
 

--- a/crates/flowmux-editor/src/lib.rs
+++ b/crates/flowmux-editor/src/lib.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-//! Safe document I/O for the Flowmux editor.
+//! Safe document I/O for the flowmux editor.
 //!
 //! UI code never reads or writes arbitrary paths directly. `DocumentService`
 //! owns workspace boundaries, text decoding, version checks, external-change

--- a/crates/flowmux-editor/src/web_assets.rs
+++ b/crates/flowmux-editor/src/web_assets.rs
@@ -320,7 +320,7 @@ mod tests {
         assert!(index.contains("font-src 'self' data:"));
         assert!(!index.contains("script-src 'self' 'unsafe-inline'"));
         assert!(index.contains("Cross-Origin-Resource-Policy: same-origin"));
-        assert!(index.contains("Flowmux editor"));
+        assert!(index.contains("flowmux editor"));
 
         let worker = request(&server, "HEAD", "editor.worker.js");
         assert!(worker.starts_with("HTTP/1.1 200 OK\r\n"));

--- a/crates/flowmux/src/main.rs
+++ b/crates/flowmux/src/main.rs
@@ -300,7 +300,7 @@ fn main() -> anyhow::Result<()> {
         {
             // macOS can emit another application activation while presenting
             // a secondary window. Do not raise the main window over an image
-            // viewer (or another FlowMux window) that is already active.
+            // viewer (or another flowmux window) that is already active.
             let active_window_is_active = app
                 .active_window()
                 .as_ref()

--- a/crates/flowmux/src/ui/browser_pane_webkit.rs
+++ b/crates/flowmux/src/ui/browser_pane_webkit.rs
@@ -184,7 +184,7 @@ impl BrowserPane {
 
                 // WebKit requires a related WebView return value before it
                 // completes window.open(). The real destination is routed to
-                // a FlowMux browser tab above, so keep this contract-only view
+                // a flowmux browser tab above, so keep this contract-only view
                 // hidden and block its duplicate navigation.
                 //
                 // Tearing the view down on the next main-loop turn is NOT

--- a/crates/flowmux/src/ui/options_dialog.rs
+++ b/crates/flowmux/src/ui/options_dialog.rs
@@ -381,13 +381,13 @@ fn update_tab_props(state: &BannerState, origin: InstallOrigin) -> UpdateTabProp
             check_sensitive: true,
         },
         BannerState::Current => UpdateTabProps {
-            status: "You are using the latest version of FlowMux.".into(),
+            status: "You are using the latest version of flowmux.".into(),
             update_version: None,
             update_label: None,
             check_sensitive: true,
         },
         BannerState::Available(version) | BannerState::Ignored(version) => UpdateTabProps {
-            status: format!("FlowMux v{version} is available."),
+            status: format!("flowmux v{version} is available."),
             update_version: Some(*version),
             update_label: Some(match crate::update::origin::update_gate(origin) {
                 UpdateGate::SourceBuild => format!("Update to v{version}"),
@@ -396,19 +396,19 @@ fn update_tab_props(state: &BannerState, origin: InstallOrigin) -> UpdateTabProp
             check_sensitive: true,
         },
         BannerState::Running(Stage::Fetching, percent, version) => UpdateTabProps {
-            status: format!("Downloading FlowMux v{version}: {percent}%"),
+            status: format!("Downloading flowmux v{version}: {percent}%"),
             update_version: None,
             update_label: None,
             check_sensitive: false,
         },
         BannerState::Running(Stage::Installing, percent, version) => UpdateTabProps {
-            status: format!("Building and installing FlowMux v{version}: {percent}%"),
+            status: format!("Building and installing flowmux v{version}: {percent}%"),
             update_version: None,
             update_label: None,
             check_sensitive: false,
         },
         BannerState::Done(version) => UpdateTabProps {
-            status: format!("FlowMux v{version} is installed. Restart FlowMux to use it."),
+            status: format!("flowmux v{version} is installed. Restart flowmux to use it."),
             update_version: None,
             update_label: None,
             check_sensitive: true,
@@ -498,7 +498,7 @@ fn show_newer_update_prompt(
     on_choice: impl FnOnce(Option<Version>) + 'static,
 ) {
     let body = format!(
-        "You were about to update to FlowMux v{selected}, but v{latest} is now available. Which version would you like to install?"
+        "You were about to update to flowmux v{selected}, but v{latest} is now available. Which version would you like to install?"
     );
     let dialog = adw::AlertDialog::new(Some("A newer version is available"), Some(&body));
     dialog.add_response("cancel", "Cancel");
@@ -539,7 +539,7 @@ fn build_update_tab(
 
     let group = adw::PreferencesGroup::builder()
         .title("Software Update")
-        .description("Check for a new FlowMux release and use the update action for this install.")
+        .description("Check for a new flowmux release and use the update action for this install.")
         .build();
 
     let version_row = adw::ActionRow::builder()
@@ -665,7 +665,7 @@ fn build_update_tab(
             if crate::update::origin::update_gate(install_origin) == UpdateGate::ReleasePage {
                 match crate::ui::update_banner::open_release_page(install_origin, selected) {
                     Ok(()) => status_row
-                        .set_subtitle(&format!("Opened the release page for FlowMux v{selected}.")),
+                        .set_subtitle(&format!("Opened the release page for flowmux v{selected}.")),
                     Err(error) => {
                         tracing::warn!(%error, %selected, "could not open release page");
                         status_row.set_subtitle(&format!("Could not open the release page: {error}"));
@@ -794,10 +794,10 @@ fn show_about_popup(parent: &impl IsA<gtk::Widget>) {
 
 fn about_body_with_version(version: &str) -> String {
     format!(
-        "FlowMux - Agent Workflow Multiplexer Terminal\n\n\
-         FlowMux was inspired by the cmux (macOS) project.\n\n\
+        "flowmux - Agent Workflow Multiplexer Terminal\n\n\
+         flowmux was inspired by the cmux (macOS) project.\n\n\
          Maintained by JSUYA (Junsu Choi).\n\
-         <a href=\"https://github.com/flowmux-ai/flowmux-terminal\">https://github.com/flowmux-ai/flowmux-terminal</a>\n\n\
+         <a href=\"https://github.com/flowmux-ai/flowmux\">https://github.com/flowmux-ai/flowmux</a>\n\n\
          Version: v{}",
         version
     )
@@ -1315,11 +1315,11 @@ mod tests {
     #[test]
     fn about_body_contains_requested_copy() {
         let body = about_body_with_version("9.8.7-6");
-        assert!(body.contains("FlowMux - Agent Workflow Multiplexer Terminal"));
-        assert!(body.contains("FlowMux was inspired by the cmux (macOS) project."));
+        assert!(body.contains("flowmux - Agent Workflow Multiplexer Terminal"));
+        assert!(body.contains("flowmux was inspired by the cmux (macOS) project."));
         assert!(body.contains("Maintained by JSUYA (Junsu Choi)."));
         assert!(body.contains(
-            "<a href=\"https://github.com/flowmux-ai/flowmux-terminal\">https://github.com/flowmux-ai/flowmux-terminal</a>"
+            "<a href=\"https://github.com/flowmux-ai/flowmux\">https://github.com/flowmux-ai/flowmux</a>"
         ));
         assert!(body.ends_with("Version: v9.8.7-6"));
     }

--- a/crates/flowmux/src/ui/update_banner.rs
+++ b/crates/flowmux/src/ui/update_banner.rs
@@ -23,7 +23,7 @@ fn banner_props(
             (String::new(), None, false, None, false)
         }
         BannerState::Available(v) => (
-            format!("FlowMux {v} is available"),
+            format!("flowmux {v} is available"),
             Some(match update::origin::update_gate(origin) {
                 UpdateGate::SourceBuild => "Update",
                 UpdateGate::ReleasePage => "Open release page (.deb)",
@@ -47,7 +47,7 @@ fn banner_props(
             false,
         ),
         BannerState::Done(v) => (
-            format!("FlowMux {v} is installed. Restart FlowMux to use it."),
+            format!("flowmux {v} is installed. Restart flowmux to use it."),
             Some("Dismiss"),
             true,
             None,
@@ -361,7 +361,7 @@ mod tests {
     fn done_announces_next_launch_and_dismisses() {
         let (title, button, revealed, progress, ignore) =
             banner_props(&BannerState::Done(V), InstallOrigin::Source);
-        assert!(title.contains("Restart FlowMux"), "{title}");
+        assert!(title.contains("Restart flowmux"), "{title}");
         assert_eq!(button, Some("Dismiss"));
         assert!(revealed);
         assert_eq!(progress, None);

--- a/crates/flowmux/src/ui/window/file_browser.rs
+++ b/crates/flowmux/src/ui/window/file_browser.rs
@@ -102,7 +102,7 @@ impl WindowController {
         // A file owns one pane-level Editor surface, just like a terminal tab.
         // Never reuse an existing editor for a different file: doing so hides
         // the previous document inside the WebView instead of leaving a visible
-        // FlowMux tab the user can move, split, or return to.
+        // flowmux tab the user can move, split, or return to.
         let editor_root = editor_workspace_root(&path, &workspace_state.root_dir);
         let Some((workspace_id, editor_surface)) = self
             .store

--- a/crates/flowmux/src/ui/window/mod.rs
+++ b/crates/flowmux/src/ui/window/mod.rs
@@ -1207,7 +1207,7 @@ impl WindowController {
             if self.stack.child_by_name("__empty").is_none() {
                 let status = adw::StatusPage::builder()
                     .icon_name("utilities-terminal-symbolic")
-                    .title("FlowMux")
+                    .title("flowmux")
                     .description("No workspaces yet")
                     .build();
                 self.stack.add_named(&status, Some("__empty"));

--- a/crates/flowmux/src/update/install.rs
+++ b/crates/flowmux/src/update/install.rs
@@ -16,7 +16,7 @@ use std::sync::{
     Arc,
 };
 
-const REPO_URL: &str = "https://github.com/flowmux-ai/flowmux-terminal.git";
+const REPO_URL: &str = "https://github.com/flowmux-ai/flowmux.git";
 const CHECK_INTERVAL: std::time::Duration = std::time::Duration::from_secs(24 * 60 * 60);
 
 #[derive(Clone)]

--- a/crates/flowmux/src/update/origin.rs
+++ b/crates/flowmux/src/update/origin.rs
@@ -72,7 +72,7 @@ pub fn update_gate(origin: InstallOrigin) -> UpdateGate {
 
 pub fn release_page_url(version: Version) -> String {
     format!(
-        "https://github.com/flowmux-ai/flowmux-terminal/releases/tag/{}",
+        "https://github.com/flowmux-ai/flowmux/releases/tag/{}",
         version.tag()
     )
 }

--- a/docs/ide-editor-plan.md
+++ b/docs/ide-editor-plan.md
@@ -1,21 +1,21 @@
 <!-- SPDX-License-Identifier: GPL-3.0-or-later -->
 
-# Flowmux pane 내장 에디터 구현 계획
+# flowmux pane 내장 에디터 구현 계획
 
 ## 1. 문서 목적
 
-이 문서는 Flowmux에 확장 마켓이나 별도 IDE shell을 넣지 않고도, 일상적인 개발 작업에 충분히 정밀하고 안정적인 pane 내장 편집 환경을 추가하기 위한 구현 계획이다.
+이 문서는 flowmux에 확장 마켓이나 별도 IDE shell을 넣지 않고도, 일상적인 개발 작업에 충분히 정밀하고 안정적인 pane 내장 편집 환경을 추가하기 위한 구현 계획이다.
 
 핵심 목표는 다음과 같다.
 
 - 파일 뷰어에서 파일을 한 번 클릭하거나 `Enter`를 누르면 적절한 pane에서 즉시 편집한다.
 - 편집, 저장, 찾기, 바꾸기, 빠른 파일 열기, 워크스페이스 검색을 제품 기본 기능으로 제공한다.
 - 파일 변경 충돌, dirty 문서 종료, 비정상 종료 복구까지 포함해 데이터 손실을 방지한다.
-- Flowmux의 기존 pane, surface, focus, tab, workspace 복원 구조에 자연스럽게 통합한다.
+- flowmux의 기존 pane, surface, focus, tab, workspace 복원 구조에 자연스럽게 통합한다.
 - 언어별 지능형 기능은 핵심 편집기가 안정된 뒤 선택적인 후속 작업으로 분리한다.
-- 범용 IDE shell을 복제하지 않고 terminal·browser·file browser와 조화를 이루는 Flowmux 고유의 편집 경험을 만든다.
+- 범용 IDE shell을 복제하지 않고 terminal·browser·file browser와 조화를 이루는 flowmux 고유의 편집 경험을 만든다.
 
-이 계획에서 `Editor surface`는 Flowmux pane의 바깥 tab 하나를 뜻한다. 화면에는 현재 파일 하나만 표시하며, 다른 파일 선택은 기존 file browser가 담당한다.
+이 계획에서 `Editor surface`는 flowmux pane의 바깥 tab 하나를 뜻한다. 화면에는 현재 파일 하나만 표시하며, 다른 파일 선택은 기존 file browser가 담당한다.
 
 ## 구현 상태 (2026-07-19)
 
@@ -77,7 +77,7 @@ workspace 일괄 바꾸기, 별도 Workspace Tools 패널, 직접 LSP 연동과 
 
 ## 3. 현재 구조에서 확인된 연결 지점
 
-현재 Flowmux에는 `Terminal`과 `Browser` 두 surface 종류가 있으며, pane 하나가 여러 surface를 tab으로 관리한다.
+현재 flowmux에는 `Terminal`과 `Browser` 두 surface 종류가 있으며, pane 하나가 여러 surface를 tab으로 관리한다.
 
 - surface 모델: `crates/flowmux-core/src/lib.rs`
 - surface 렌더링 및 `PaneRegistry`: `crates/flowmux/src/ui/workspace_view.rs`
@@ -94,7 +94,7 @@ workspace 일괄 바꾸기, 별도 Workspace Tools 패널, 직접 LSP 연동과 
 
 ### 4.1 편집 엔진은 Monaco Editor를 직접 사용한다
 
-Monaco는 편집 품질과 접근 가능한 API가 충분하고, Flowmux 전용 UI를 구성하기 쉽다. 다만 Monaco는 독립 편집기일 뿐 VS Code 확장 실행 환경이 아니며, 이번 계획에서도 그런 호환성을 만들지 않는다.
+Monaco는 편집 품질과 접근 가능한 API가 충분하고, flowmux 전용 UI를 구성하기 쉽다. 다만 Monaco는 독립 편집기일 뿐 VS Code 확장 실행 환경이 아니며, 이번 계획에서도 그런 호환성을 만들지 않는다.
 
 초기 선택은 다음과 같다.
 
@@ -133,14 +133,14 @@ Workspace
 
 이 구조의 장점은 다음과 같다.
 
-- 기존 Flowmux tab이 현재 파일 이름을 표시하므로 tab을 중첩하지 않는다.
+- 기존 flowmux tab이 현재 파일 이름을 표시하므로 tab을 중첩하지 않는다.
 - 파일 선택과 전환은 기존 file browser 한 곳에서 처리한다.
 - 파일 수가 늘어도 WebView와 worker 수가 파일 수만큼 증가하지 않는다.
 - 저장, 검색, LSP, 복구 상태를 Editor 단위에서 일관되게 관리할 수 있다.
 
 동일 pane에서 이미 열린 파일은 기존 document model을 재사용한다. 다른 pane의 Editor surface로 focus를 강제로 옮기지 않고 사용자가 파일을 연 대상 pane을 우선한다.
 
-### 4.3 Flowmux가 파일 상태의 최종 소유자다
+### 4.3 flowmux가 파일 상태의 최종 소유자다
 
 WebView JavaScript가 경로를 받아 직접 파일을 읽거나 쓰게 하지 않는다. Rust의 `DocumentService`가 다음을 전담한다.
 
@@ -303,13 +303,13 @@ Markdown preview와 `Open Externally`는 context menu의 명시적 동작으로 
 - `identity_path`: 중복 판별과 file watcher용 canonical path
 - `save_path`: 실제 저장 대상이며 symlink 정책을 따른다
 
-workspace 밖을 가리키는 symlink를 열 수 있는지는 기존 Flowmux 보안 정책과 함께 결정한다. 정책 확정 전에는 경계를 넘는 파일을 read-only로 여는 것이 안전한 기본값이다.
+workspace 밖을 가리키는 symlink를 열 수 있는지는 기존 flowmux 보안 정책과 함께 결정한다. 정책 확정 전에는 경계를 넘는 파일을 read-only로 여는 것이 안전한 기본값이다.
 
 ## 7. 편집기 UX
 
 ### 7.1 화면 구성
 
-Flowmux Editor는 별도 IDE shell이나 activity bar를 만들지 않는다.
+flowmux Editor는 별도 IDE shell이나 activity bar를 만들지 않는다.
 
 ```text
 ┌─ current file ─────────────────────────────────────┐
@@ -320,7 +320,7 @@ Flowmux Editor는 별도 IDE shell이나 activity bar를 만들지 않는다.
 └─────────────────────────────────────────────────────┘
 ```
 
-- 바깥 Flowmux tab: 현재 파일 이름을 표시하고 Terminal·Browser·파일 편집 화면을 전환
+- 바깥 flowmux tab: 현재 파일 이름을 표시하고 Terminal·Browser·파일 편집 화면을 전환
 - 편집 화면: 우측 상단 mode switch 외 toolbar, document tab, context rail, status strip 없이 Monaco가 pane을 채움
 - 저장 상태: 평상시 숨기고 dirty, read-only, external-change일 때만 작은 상태 표시
 - 기존 file browser: 프로젝트 탐색의 유일한 기본 UI
@@ -340,7 +340,7 @@ Flowmux Editor는 별도 IDE shell이나 activity bar를 만들지 않는다.
 
 ### 7.3 focus와 shortcut 정책
 
-shortcut은 focus context에 따라 해석한다. 기존 Flowmux 전역 shortcut을 빼앗지 않는다.
+shortcut은 focus context에 따라 해석한다. 기존 flowmux 전역 shortcut을 빼앗지 않는다.
 
 | 입력 | Editor focus일 때 |
 |---|---|
@@ -353,8 +353,8 @@ shortcut은 focus context에 따라 해석한다. 기존 Flowmux 전역 shortcut
 | `Ctrl+P` | 빠른 파일 열기 |
 | `Ctrl+G` | 줄로 이동 |
 | `Ctrl+W` | 현재 문서 닫기 |
-| `Alt+W` | 기존 Flowmux surface 닫기 유지 |
-| `Ctrl+Shift+P` | 기존 Flowmux command palette 유지, Editor 명령도 등록 |
+| `Alt+W` | 기존 flowmux surface 닫기 유지 |
+| `Ctrl+Shift+P` | 기존 flowmux command palette 유지, Editor 명령도 등록 |
 
 IME 조합 중에는 전역 command가 키 입력을 가로채지 않도록 composition 상태를 반드시 확인한다.
 
@@ -394,7 +394,7 @@ IME 조합 중에는 전역 command가 키 입력을 가로채지 않도록 comp
 - pane 닫기
 - workspace 닫기
 - tear-off window 닫기
-- Flowmux 종료
+- flowmux 종료
 
 dirty 문서가 있으면 `Save`, `Discard`, `Cancel`을 제공한다. 여러 문서가 dirty이면 문서별 선택이 가능한 목록을 표시한다. 저장 실패 후에는 닫기를 계속 진행하지 않는다.
 
@@ -431,7 +431,7 @@ dirty buffer는 debounce된 recovery snapshot으로 저장한다.
 
 `SearchService`가 workspace 파일 index를 background에서 만든다.
 
-- `.gitignore`, 숨김 파일 정책, Flowmux exclude 설정을 존중한다.
+- `.gitignore`, 숨김 파일 정책, flowmux exclude 설정을 존중한다.
 - fuzzy score와 최근 열었던 파일 가중치를 함께 사용한다.
 - 결과는 상대 경로와 상위 디렉터리를 함께 표시한다.
 - index 갱신은 file watcher event를 증분 반영한다.
@@ -494,7 +494,7 @@ workspace 일괄 바꾸기는 v1에 포함하지 않는다. 후속 구현을 결
 - WebKitGTK와 WKWebView에서 Monaco worker 로드
 - 한글·일본어 IME와 composition event
 - clipboard, multi-cursor, undo/redo
-- Flowmux global shortcut과 Editor shortcut의 focus 분리
+- flowmux global shortcut과 Editor shortcut의 focus 분리
 - theme 전환, zoom, screen reader 기본 동작
 - 10만 줄 파일, 긴 한 줄 파일, 다수 document model의 반응성
 - 한 pane당 WebView 메모리와 첫 usable frame 시간
@@ -622,7 +622,7 @@ workspace 일괄 바꾸기와 별도 Workspace Tools panel은 v1 이후에 각�
 - pane split/drag/tear-off/close와 앱 종료 회귀 검사
 - frontend dependency lock, license notice, SBOM 갱신
 - Linux 패키징과 macOS bundle asset 경로 검증
-- 실제 실행 중인 Flowmux에서 사용자 시나리오 검증
+- 실제 실행 중인 flowmux에서 사용자 시나리오 검증
 
 완료 조건:
 
@@ -666,7 +666,7 @@ workspace 일괄 바꾸기와 별도 Workspace Tools panel은 v1 이후에 각�
 
 ### 12.3 실제 UI 검증
 
-자동 테스트만으로 완료 처리하지 않는다. 최소한 Ubuntu 24.04의 실행 중인 Flowmux에서 다음 시나리오를 재현한다.
+자동 테스트만으로 완료 처리하지 않는다. 최소한 Ubuntu 24.04의 실행 중인 flowmux에서 다음 시나리오를 재현한다.
 
 1. terminal이 최근 focus된 pane과 file browser source pane이 다른 상태를 만든다.
 2. file browser에서 텍스트 파일을 한 번 클릭한다.
@@ -713,7 +713,7 @@ large-file mode는 syntax tokenization, minimap, semantic 기능을 단계적으
 
 - Monaco Editor의 MIT license와 notice를 배포물에 포함한다.
 - frontend의 직접·전이 dependency license를 lockfile 기준으로 수집한다.
-- GPL-3.0-or-later인 Flowmux source와 함께 필요한 source·notice 제공 의무를 유지한다.
+- GPL-3.0-or-later인 flowmux source와 함께 필요한 source·notice 제공 의무를 유지한다.
 - minified JavaScript만 배포하지 않고 대응하는 source와 재현 가능한 build 절차를 저장소에 둔다.
 - editor asset 목록을 기존 third-party license 문서 또는 전용 generated notice에 반영한다.
 - 이름, icon, UI 문구에서 Visual Studio Code 제품으로 오인될 branding을 사용하지 않는다.
@@ -739,7 +739,7 @@ large-file mode는 syntax tokenization, minimap, semantic 기능을 단계적으
 - 정한 reference hardware에서 확정된 성능 예산을 통과한다.
 - runtime Node.js, extension host, 외부 extension registry 없이 동작한다.
 - dependency license notice, source, build 절차가 배포물과 저장소에 준비되어 있다.
-- 실행 중인 Flowmux에서 사용자 시나리오 검증을 완료한다.
+- 실행 중인 flowmux에서 사용자 시나리오 검증을 완료한다.
 
 ## 17. 구현 결정 결과
 

--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -36,14 +36,14 @@ Ctrl/Cmd+P opens a file, Ctrl/Cmd+Shift+F searches the workspace, and
 Ctrl/Cmd+W closes the current document. Standard editing chords —
 Ctrl/Cmd+C/X/V copy/cut/paste, Ctrl/Cmd+A select all, Ctrl/Cmd+Z undo —
 work natively inside the editor, and the terminal-style Ctrl+Shift+C/V
-copy/paste also routes to the focused editor. Flowmux surface shortcuts
+copy/paste also routes to the focused editor. flowmux surface shortcuts
 such as Alt+W remain global.
 
 ## Context behavior
 
 | Input | Terminal, browser, or Files focused | Embedded editor focused |
 |---|---|---|
-| Flowmux layout, tab, workspace, panel, window, zoom, palette, and tig shortcuts listed above | Runs the flowmux action | Runs the same flowmux action |
+| flowmux layout, tab, workspace, panel, window, zoom, palette, and tig shortcuts listed above | Runs the flowmux action | Runs the same flowmux action |
 | copy / paste | Targets the focused terminal or file view | Targets the editor selection or cursor |
 | terminal-search | Searches the focused terminal or browser | Searches the editor workspace |
 | Alt+Arrow | Moves focus between panes | Moves focus between panes |

--- a/editor/flowmux-editor-web/THIRD_PARTY_NOTICES.md
+++ b/editor/flowmux-editor-web/THIRD_PARTY_NOTICES.md
@@ -1,4 +1,4 @@
-# Flowmux Editor Web Third-Party Notices
+# flowmux Editor Web Third-Party Notices
 
 The compiled editor assets include Monaco Editor 0.53.0 under the MIT License.
 The package version is pinned in `package-lock.json`.

--- a/editor/flowmux-editor-web/dist/THIRD_PARTY_NOTICES.md
+++ b/editor/flowmux-editor-web/dist/THIRD_PARTY_NOTICES.md
@@ -1,4 +1,4 @@
-# Flowmux Editor Web Third-Party Notices
+# flowmux Editor Web Third-Party Notices
 
 The compiled editor assets include Monaco Editor 0.53.0 under the MIT License.
 The package version is pinned in `package-lock.json`.

--- a/editor/flowmux-editor-web/dist/index.html
+++ b/editor/flowmux-editor-web/dist/index.html
@@ -7,11 +7,11 @@
       http-equiv="Content-Security-Policy"
       content="default-src 'none'; script-src 'self'; style-src 'self' 'unsafe-inline'; worker-src 'self'; font-src 'self' data:; img-src data:"
     >
-    <title>Flowmux Editor</title>
+    <title>flowmux Editor</title>
     <link rel="stylesheet" href="./main.css">
   </head>
   <body>
-    <main class="editor-shell" aria-label="Flowmux editor">
+    <main class="editor-shell" aria-label="flowmux editor">
       <section id="empty-state" class="empty-state">
         <p>Click a text file in Files to edit it.</p>
       </section>

--- a/editor/flowmux-editor-web/index.html
+++ b/editor/flowmux-editor-web/index.html
@@ -7,11 +7,11 @@
       http-equiv="Content-Security-Policy"
       content="default-src 'none'; script-src 'self'; style-src 'self' 'unsafe-inline'; worker-src 'self'; font-src 'self' data:; img-src data:"
     >
-    <title>Flowmux Editor</title>
+    <title>flowmux Editor</title>
     <link rel="stylesheet" href="./main.css">
   </head>
   <body>
-    <main class="editor-shell" aria-label="Flowmux editor">
+    <main class="editor-shell" aria-label="flowmux editor">
       <section id="empty-state" class="empty-state">
         <p>Click a text file in Files to edit it.</p>
       </section>


### PR DESCRIPTION
The repository moved from flowmux-terminal to flowmux, so update the hardcoded URLs that still pointed at the old path. Three of them are functional, not cosmetic: install.rs clones REPO_URL for self-update, origin.rs builds the release page link, and Cargo.toml carries the crates.io repository field.

Also settle on lowercase "flowmux" for the brand, matching the binary name, across the README, docs, in-app strings, and the editor WebView assets. Four spellings are deliberately left alone because they are load-bearing: the FlowMux.app bundle name that origin.rs and install.rs match on disk, the "==> restart FlowMux" line install.rs parses out of Homebrew output, the fireFlowmuxHook identifier baked into agent hook payloads, and the FLOWMUX_* environment variables.

Point the README website link at the new custom domain.